### PR TITLE
cdr -> car

### DIFF
--- a/scheme/docs/lists/filtering.md
+++ b/scheme/docs/lists/filtering.md
@@ -71,7 +71,7 @@ procedures accepting a single argument, i.e. “predicates”.  Although there a
 other procedures that match this requirement it is rarely useful to use them in
 a `filter` expression.  When interested in things like “all list elements that
 are numbers greater than 7” or “all list elements are pairs of numbers where the
-`cdr` is greater than the `cdr`” you will want to use custom procedures, which
+`car` is greater than the `cdr`” you will want to use custom procedures, which
 you'll learn to write in [Defining Procedures](../scheme/procedures/index.html).
 
 #### delete and delete-duplicates


### PR DESCRIPTION
I believe that the sentence containing "where the cdr is greater than the cdr" should have one of the "crd"s be a "car".